### PR TITLE
Use Shutterized Arbitrum devnet

### DIFF
--- a/test-node.bash
+++ b/test-node.bash
@@ -147,7 +147,7 @@ if $force_init; then
 
     echo == Deploying L2
     sequenceraddress=`docker-compose run testnode-scripts print-address --account sequencer | tail -n 1 | tr -d '\r\n'`
-    docker-compose run --entrypoint /usr/local/bin/deploy poster --l1conn ws://geth:8546 --l1keystore /home/user/l1keystore --l1DeployAccount $sequenceraddress --l1deployment /config/deployment.json --authorizevalidators 10 --wasmrootpath /home/user/target/machines
+    docker-compose run --entrypoint /usr/local/bin/deploy poster --l1conn ws://geth:8546 --l1keystore /home/user/l1keystore --l1DeployAccount $sequenceraddress --l1deployment /config/deployment.json --authorizevalidators 10 --wasmrootpath /home/user/target/machines --l2chainid 452346
 
     echo == Writing configs
     docker-compose run testnode-scripts write-config

--- a/testnode-scripts/config.ts
+++ b/testnode-scripts/config.ts
@@ -17,7 +17,7 @@ function writeConfigs(argv: any) {
             },
         },
         "l2": {
-            "chain-id": 412346,
+            "chain-id": 452346,
             "dev-wallet" : {
                 "private-key": "e887f7d17d07cc7b8004053fb8826f6657084e88904bb61590e498ca04704cf2"
             }


### PR DESCRIPTION
Now, chains run with `test-node.bash` will support batch txs. Contracts are expected to be located at the right addresses (i.e., where `hardhat deploy` deploys them, hardcoded in the submoduled go-ethereum repo as part of the `ShutterizedArbitrumDevTestChainConfig`).

Closes https://github.com/shutter-network/rolling-shutter/issues/306